### PR TITLE
Add namespace for composer, + ssl fix

### DIFF
--- a/src/HipChat/HipChat.php
+++ b/src/HipChat/HipChat.php
@@ -229,6 +229,7 @@ class HipChat {
    * 
    * @param bool $bool
    * @return bool
+   * @link http://davidwalsh.name/php-ssl-curl-error
    */
   public function set_verify_ssl($bool = true)
   {


### PR DESCRIPTION
Added namespace bits.
Also added a flag and setter method for whether or not curl should verify the hipchat api's SSL certificate. Our server had an old bundle, so I was getting errors.  I came up with this solution before figuring how to update our CA bundle.  Should be useful in shared/cloud situations where updating the CA bundle is infeasible.

I did not add a test for the new method, because I'm not sure how to consistently reproduce the error state across environments.
