### PR TITLE
Fixed bug, InvalidArgumentException on wrong namespace.

### DIFF
--- a/src/HipChat/HipChat.php
+++ b/src/HipChat/HipChat.php
@@ -92,7 +92,7 @@ class HipChat {
 
     if (!in_array($color, array(self::COLOR_YELLOW, self::COLOR_PURPLE, self::COLOR_GREEN, self::COLOR_RED, self::COLOR_RANDOM))) 
     {
-      throw new InvalidArgumentException(sprintf('Unkown color "%s"', $color));
+      throw new \InvalidArgumentException(sprintf('Unkown color "%s"', $color));
     }
 
     $args = array(


### PR DESCRIPTION
InvalidArgumentException does not exists on HipChat namespace and this causes PHP fatal error.

What probably is wanted here is to use PHP built-in \InvalidArgumentException.
