### PR TITLE
corrects phpdoc formatting to match actual function

### DIFF
--- a/src/HipChat/HipChat.php
+++ b/src/HipChat/HipChat.php
@@ -54,10 +54,10 @@ class HipChat {
   /**
    * Creates a new API interaction object.
    *
-   * @param $auth_token   Your API token.
-   * @param $api_target   API protocol and host. Change if you're using an API
-   *                      proxy such as apigee.com.
-   * @param $api-version  Version of API to use.
+   * @param $auth_token string Your API token.
+   * @param $api_target string API protocol and host. Change if you're using an API
+   *                           proxy such as apigee.com.
+   * @param $api_version string Version of API to use.
    */
   function __construct($auth_token, $api_target = self::DEFAULT_TARGET,
                        $api_version = self::VERSION_1) {


### PR DESCRIPTION
my ide (phpstorm 7) was reporting some mis-matched expected types for the token (it wanted a "Your" object) and target (an "API" object). adding the 'string' after the variable name fixes this. also changes the $api_version from a dash to an underscore to reflect actual code use.
