### PR TITLE
Force room names to UTF-8.

### DIFF
--- a/src/HipChat/HipChat.php
+++ b/src/HipChat/HipChat.php
@@ -171,7 +171,7 @@ class HipChat {
    */
    public function create_room($name, $owner_user_id = null, $privacy = null, $topic = null, $guest_access = null) {
      $args = array(
-       'name' => $name
+       'name' => utf8_encode($name)
      );
 
      if ($owner_user_id) {


### PR DESCRIPTION
I haven't duplicated this issue elsewhere, but the Mac HipChat client specifically won't work at all if you have a room that has foreign characters in the name.
